### PR TITLE
Avoid depreciation warning in WP debug mode

### DIFF
--- a/posts-by-tag.php
+++ b/posts-by-tag.php
@@ -371,6 +371,10 @@ function posts_by_tag_init() {
 }
 add_action( 'init', 'posts_by_tag_init' );
 
-// register TagWidget widget
-add_action( 'widgets_init', create_function( '', 'return register_widget("TagWidget");' ) );
+// Init Simple Tags widget
+function simple_tags_register_widget() {
+  return register_widget("TagWidget");
+}
+add_action( 'widgets_init', 'simple_tags_register_widget' );
+
 ?>


### PR DESCRIPTION
As per: https://wordpress.org/support/topic/bug-php-7-create_function-is-deprecated/

Just hoping to get this merged so that I can update the plugin with confidence. Current call to `create_function()` throws a depreciation warning in PHP 7.